### PR TITLE
Forget to Forgot Password

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -14,7 +14,7 @@
           </label>
         </div>
         <div class="px-10 py-4 bg-gray-100 border-t border-gray-100 flex justify-between items-center">
-          <a class="hover:underline" tabindex="-1" href="#reset-password">Forget password?</a>
+          <a class="hover:underline" tabindex="-1" href="#reset-password">Forgot password?</a>
           <loading-button :loading="form.processing" class="btn-indigo" type="submit">Login</loading-button>
         </div>
       </form>


### PR DESCRIPTION
Suggesting changing spelling of forget password (with an e) to forgot password(with an o).